### PR TITLE
Implement Pick

### DIFF
--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Pick.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Pick.scala
@@ -1,0 +1,132 @@
+package net.exoego.scalajs.types.util
+
+import scala.annotation.StaticAnnotation
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+import scala.scalajs.js
+
+/**
+  * Enrich the annotated type with only picked members of `T`.
+  *
+  * If the below code given,
+  *
+  * {{{
+  * @js.native
+  * trait Base extends js.Object {
+  *   var foo: String = js.native
+  *   val bar: js.Array[Int] = js.native
+  *   def buz(x: String): Boolean = js.native
+  * }
+  *
+  * @Pick[Base]("foo", "buz")
+  * @js.native
+  * trait Enriched extends js.Object {
+  *   var ownProp: String = js.native
+  * }
+  * }}}
+  *
+  * The `Enriched` will be:
+  *
+  * {{{
+  *   @js.native
+  *   trait Enriched extends js.Object {
+  *     var ownProp: String = js.native
+  *
+  *     // Picked from `Base`
+  *     var foo: String = js.native
+  *     def buz(x: String): Boolean = js.native
+  *   }
+  * }}}
+  *
+  * @tparam T
+  */
+class Pick[T <: js.Object](keys: String*) extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro Pick.impl
+}
+
+object Pick {
+  def impl(c: blackbox.Context)(annottees: c.Expr[Any]*) = {
+    import c.universe._
+
+    def bail(message: String) = c.abort(c.enclosingPosition, message)
+
+    val specifiedFieldNames: Set[String] = c.prefix.tree match {
+      case q"new Pick[$a](..$b)" => b.map(_.toString.drop(1).dropRight(1)).toSet
+      case _                     => bail("""@Pick requires a type argument T and at-least one field names to be picked from T.""")
+    }
+    val argumentType: Type = {
+      val macroTypeWithArguments          = c.typecheck(q"${c.prefix.tree}").tpe
+      val annotationClass: ClassSymbol    = macroTypeWithArguments.typeSymbol.asClass
+      val annotationTypePlaceholder: Type = annotationClass.typeParams.head.asType.toType
+      annotationTypePlaceholder.asSeenFrom(macroTypeWithArguments, annotationClass)
+    }
+    if (argumentType.finalResultType == c.typeOf[Nothing]) {
+      bail("Type parameter T must be provided")
+    }
+
+    val inputs = annottees.map(_.tree).toList
+    if (!inputs.headOption.exists(_.isInstanceOf[ClassDef])) {
+      bail("Can annotate only trait")
+    }
+    def toPick(s: Symbol, isJsNative: Boolean): Tree = {
+      val decodedName = s.name.decodedName.toString
+      val name        = TermName(decodedName)
+      if (!specifiedFieldNames.contains(decodedName)) {
+        EmptyTree
+      } else {
+        val stringRep = s.toString
+        if (stringRep.startsWith("variable ")) {
+          val m       = s.asMethod
+          val retType = m.returnType
+          if (isJsNative) {
+            q"var $name: $retType = scala.scalajs.js.native"
+          } else {
+            q"var $name: $retType"
+          }
+        } else if (stringRep.startsWith("value ")) {
+          val tpt = s.typeSignature
+          if (isJsNative) {
+            q"val $name: $tpt = scala.scalajs.js.native"
+          } else {
+            q"val $name: $tpt"
+          }
+        } else {
+          val m = s.asMethod
+          val paramss = m.paramLists.map(_.map(param => {
+            internal.valDef(param)
+          }))
+          val retType = m.returnType
+          if (isJsNative) {
+            q"def $name (...$paramss): $retType = scala.scalajs.js.native"
+          } else {
+            q"def $name (...$paramss): $retType"
+          }
+        }
+      }
+    }
+    annottees.map(_.tree) match {
+      case List(
+          q"$mods trait $tpname[..$tparams] extends { ..$earlydefns } with ..$parents { $self => ..$ownMembers }"
+          ) =>
+        val isJsNative = mods.annotations.exists {
+          case q"new scala.scalajs.js.native()" => true
+          case q"new scalajs.js.native()"       => true
+          case q"new js.native()"               => true
+          case _                                => false
+        }
+        val inheritedMembers =
+          // maybe decls instead of members?
+          (argumentType.members.toSet -- c.typeOf[js.Object].members.toSet).toList
+            .filterNot(_.isConstructor)
+            .sortBy(_.name.decodedName.toString)
+        val partialMembers = inheritedMembers.map(s => toPick(s, isJsNative))
+        c.Expr[Any](q"""
+          $mods trait $tpname[..$tparams] extends { ..$earlydefns } with ..$parents { $self => 
+            ..$ownMembers
+            ..$partialMembers
+          }
+        """)
+      case _ => bail("Must be a trait")
+    }
+  }
+}

--- a/macros/src/test/scala/net/exoego/scalajs/types/util/PickTest.scala
+++ b/macros/src/test/scala/net/exoego/scalajs/types/util/PickTest.scala
@@ -1,0 +1,92 @@
+package net.exoego.scalajs.types.util
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.scalajs.js
+
+class PickTest extends AnyFlatSpec with Matchers {
+  "Pick macro" should "not compile when NOT applied to a trait" in {
+    """@Pick def x: String = "a"""" shouldNot compile
+    """@Pick var x: String = "a"""" shouldNot compile
+    """@Pick val x: String = "a"""" shouldNot compile
+    """@Pick class X""" shouldNot compile
+    """@Pick object X""" shouldNot compile
+    """def x(@Pick y: Int): String = "a"""" shouldNot compile
+  }
+
+  it should "not compile when applied to a trait without type argument" in {
+    """@Pick trait X {}""" shouldNot compile
+  }
+
+  it should "not compile when applied to a trait with type argument but no keys" in {
+    """ @Pick[Foo] trait Y {}""".stripMargin shouldNot compile
+    """ @Pick[Foo]() trait Y {}""".stripMargin shouldNot compile
+    """ @Pick[Bar] trait Y {}""".stripMargin shouldNot compile
+    """ @Pick[Bar]() trait Y {}""".stripMargin shouldNot compile
+  }
+
+  it should "not compile when applied to a trait with type argument and some keys" in {
+    """ @Pick[Foo]("") trait Y {}""".stripMargin should compile
+    """ @Pick[Bar]("") trait Y {}""".stripMargin should compile
+  }
+
+  it should "have own property as-is" in {
+    """ val a: PickFoo = ???
+      | val b: Boolean = a.own
+      | """.stripMargin should compile
+    """ val a: PickBar = ???
+      | val b: Boolean = a.own
+      | """.stripMargin should compile
+  }
+
+  it should "have picked members" in {
+    """ val a: PickFoo = ???
+      | val b: String = a.name
+      | """.stripMargin should compile
+
+    """ val a: PickBar = ???
+      | val b: String = a.name
+      | """.stripMargin should compile
+
+    """ val a: PickFoo2 = ???
+      | val b: String = a.name
+      | val c: js.Array[Int] = a.x
+      | val d: Int = a.bar("yay")
+      | """.stripMargin should compile
+  }
+
+  it should "not have un-picked members" in {
+    """ val a: PickFoo = ???
+      | a.x
+      | """.stripMargin shouldNot compile
+    """ val a: PickFoo = ???
+      | a.bar("yay")
+      | """.stripMargin shouldNot compile
+
+    """ val a: PickBar = ???
+      | a.x
+      | """.stripMargin shouldNot compile
+    """ val a: PickBar = ???
+      | a.bar("yay")
+      | """.stripMargin shouldNot compile
+  }
+}
+
+@Pick[Foo]("name")
+@js.native
+trait PickFoo extends js.Object {
+  var own: Boolean        = js.native
+  def buz(x: String): Int = js.native
+}
+
+@Pick[Foo]("name", "x", "bar")
+@js.native
+trait PickFoo2 extends js.Object
+
+@Pick[Bar]("name")
+@js.native
+trait PickBar extends js.Object {
+  var own: Boolean
+  def buz(x: String): Int
+}


### PR DESCRIPTION
Closes #5 

Implement Pick in the form of `@Pick[T]("foo", "bar", "buz")`.

In TypeScript, it is `Pick<T, K>` where `K` is union of literal type (e.g. `"foo" | "bar" | "buz"`). 
But this PR chosed the varargs instead of type parameter `K`, since Scala does not support union type.